### PR TITLE
feat: create bill model

### DIFF
--- a/src/models/Bill.model.ts
+++ b/src/models/Bill.model.ts
@@ -1,0 +1,24 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity("class plural")
+class Bill {
+  @PrimaryGeneratedColumn("uuid")
+  readonly id: string;
+
+  @Column({ type: "boolean" })
+  paid: boolean;
+
+  @CreateDateColumn({ type: "timestamptz" })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: "timestamptz" })
+  updated_at: Date;
+}
+
+export default Bill;


### PR DESCRIPTION
- column total is calculated automaticaly based on the orders related to the bill, it will be added later, just like the OneToMany field to list the orders