### PR TITLE
fix: now input to create an ingredient is normalized using a middleware

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -1,10 +1,12 @@
 import * as express from "express";
+import { ICreateIngredient } from "../../src/interfaces/Ingredient.interface";
 import Employee from "../../src/models/Employee.model";
 
 declare global {
   namespace Express {
     interface Request {
       user: Employee;
+      ingredientInfo: ICreateIngredient;
     }
   }
 }

--- a/src/controllers/Ingredient.controller.ts
+++ b/src/controllers/Ingredient.controller.ts
@@ -7,7 +7,7 @@ import ShowIngredientService from "../services/Ingredients/ShowIngredient.servic
 
 class IngredientController {
   static async store(req: Request, res: Response) {
-    const ingredientInfo: ICreateIngredient = req.body;
+    const ingredientInfo: ICreateIngredient = req.ingredientInfo;
 
     const ingredient = await CreateIngredientService.execute(ingredientInfo);
 

--- a/src/interfaces/Ingredient.interface.ts
+++ b/src/interfaces/Ingredient.interface.ts
@@ -2,6 +2,6 @@ export interface ICreateIngredient {
   name: string;
   measure: string;
   amount: number;
-  amount_max: number;
-  amount_min: number;
+  amountMax: number;
+  amountMin: number;
 }

--- a/src/middlewares/ingredients/normalizeIngredient.middleware.ts
+++ b/src/middlewares/ingredients/normalizeIngredient.middleware.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from "express";
+import { ICreateIngredient } from "../../interfaces/Ingredient.interface";
+import { normalizeTextInput, roundToTwo } from "../../utils";
+
+const normalizeIngredientMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { name, measure, amount, amountMax, amountMin }: ICreateIngredient =
+    req.body;
+
+  const normalizedIngredient = {
+    name: normalizeTextInput(name),
+    measure: normalizeTextInput(measure),
+    amount: roundToTwo(amount),
+    amountMax: roundToTwo(amountMax),
+    amountMin: roundToTwo(amountMin),
+  };
+
+  req.ingredientInfo = normalizedIngredient;
+
+  next();
+};
+
+export default normalizeIngredientMiddleware;

--- a/src/routes/ingredients.routes.ts
+++ b/src/routes/ingredients.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { expressYupMiddleware } from "express-yup-middleware";
 
 import IngredientController from "../controllers/Ingredient.controller";
+import normalizeIngredientMiddleware from "../middlewares/ingredients/normalizeIngredient.middleware";
 import createIngredientSchema from "../schemas/ingredients/createIngredient.schema";
 import validateUUIDSchema from "../schemas/validateUUID.schema";
 
@@ -10,6 +11,7 @@ const ingredientsRoutes = Router();
 ingredientsRoutes.post(
   "/",
   expressYupMiddleware({ schemaValidator: createIngredientSchema }),
+  normalizeIngredientMiddleware,
   IngredientController.store
 );
 ingredientsRoutes.get("/", IngredientController.index);

--- a/src/schemas/ingredients/createIngredient.schema.ts
+++ b/src/schemas/ingredients/createIngredient.schema.ts
@@ -9,23 +9,19 @@ const createIngredientSchema = {
         name: yup
           .string()
           .max(164, "name field has a max of 164 characters")
-          .required("name field is required")
-          .transform((value: string) => value.toLowerCase().trim()),
+          .required("name field is required"),
         measure: yup
           .string()
           .max(3, "measure field has a max of 3 characters")
-          .required("measure field is required")
-          .transform((value: string) => value.toLowerCase().trim()),
+          .required("measure field is required"),
         amount: yup
           .number()
           .positive("amount field can't be negative")
-          .required("amount field is required")
-          .transform((value: number) => roundToTwo(value)),
+          .required("amount field is required"),
         amountMax: yup
           .number()
           .positive("amountMax field can't be negative")
-          .required("amountMax field is required")
-          .transform((value: number) => roundToTwo(value)),
+          .required("amountMax field is required"),
         amountMin: yup
           .number()
           .positive("amountMin field can't be negative")
@@ -33,8 +29,7 @@ const createIngredientSchema = {
           .lessThan(
             yup.ref("amountMax"),
             "amountMin should be less than amountMax"
-          )
-          .transform((value: number) => roundToTwo(value)),
+          ),
       }),
       validateOptions: {
         abortEarly: false,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,4 @@
 export const roundToTwo = (n: number) =>
   Math.round((n + Number.EPSILON) * 100) / 100;
+
+export const normalizeTextInput = (s: string) => s.toLowerCase().trim();


### PR DESCRIPTION
- this was necessary because yup transform method doesn't work well with express-yup-middleware library, since there is no way to add the transformed result to the request and then the input was never normalized

ps: this is making me think that maybe andré is right and we shouldn't use this library