### PR TITLE
refact: verifyAccessLevelMiddleware now accepts either a number or a …

### DIFF
--- a/src/middlewares/verifyAccessLevel.middleware.ts
+++ b/src/middlewares/verifyAccessLevel.middleware.ts
@@ -2,15 +2,19 @@ import { NextFunction, Request, Response } from "express";
 import AppError from "../errors/AppError";
 
 const verifyAccessLevelMiddleware =
-  (accessLevel: number) =>
+  (accessLevels: number | number[]) =>
   (req: Request, res: Response, next: NextFunction) => {
     const loggedInUser = req.user;
 
-    if (loggedInUser.accessLevel > accessLevel) {
-      throw new AppError("You don't have permission to access this route", 401);
+    if (
+      (Array.isArray(accessLevels) &&
+        accessLevels.includes(loggedInUser.accessLevel)) ||
+      loggedInUser.accessLevel <= accessLevels
+    ) {
+      next();
     }
 
-    next();
+    throw new AppError("You don't have permission to access this route", 401);
   };
 
 export default verifyAccessLevelMiddleware;


### PR DESCRIPTION
…number array as argument

- when passing a number, it will be interpreted as the minimum access level demanded
- when passing an array of numbers, the users access level must be one of them